### PR TITLE
Add Return Type for Compatibility with Symfony

### DIFF
--- a/Classes/Command/FixMimeType.php
+++ b/Classes/Command/FixMimeType.php
@@ -36,7 +36,7 @@ class FixMimeType extends Command
      * @param OutputInterface $output
      * @return int error code 0 when no errors
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
         $io->title($this->getDescription());


### PR DESCRIPTION
Declaration of 
execute()
must be compatible with 
Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int